### PR TITLE
Update instructions and yum installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ For more information on how the `upstream` schema is mapped to `core`, see [this
 
 ## Installation
 
+1. Make sure you have the correct Vagrant plugins installed:
+
+    `vagrant plugin install vagrant-vbguest`
+    `vagrant vbguest`
+
 1. Clone the repository to a local folder on your computer. For example, using the SSH method:
 
     `git clone git@github.com:jamesaoverton/IEDB-in-a-Box.git`

--- a/tools/site.yml
+++ b/tools/site.yml
@@ -40,6 +40,7 @@
         - mariadb
         - postgresql-server
         - postgresql
+        - python-setuptools
         - python-psycopg2
         - python36
         - python36-psycopg2


### PR DESCRIPTION
I was not able to run `vagrant up` without first installing `vagrant-vbguest`. If users don't have this plugin installed, they will run into the same error:
```
Vagrant was unable to mount VirtualBox shared folders.
```

Additionally, I needed to add `python-setuptools` to make Ansible complete successfully after this error during task `Install further python 3 modules using pip`:
```
ImportError: No module named pkg_resources
```

After resolving, I was able to get the VM up and running and everything from there worked great. Mac OS 10.14.6.